### PR TITLE
Apply trust region to variable bounds

### DIFF
--- a/examples/tr_simple.jl
+++ b/examples/tr_simple.jl
@@ -1,4 +1,5 @@
 using BundleMethod
+using SparseArrays
 using JuMP
 using Ipopt
 using Random
@@ -50,7 +51,7 @@ set_optimizer(model, Ipopt.Optimizer)
 set_optimizer_attribute(model, "print_level", 0)
 
 # We overwrite the function to have column bounds.
-function BM.add_variables!(method::BM.ProximalMethod)
+function BM.add_variables!(method::BM.TrustRegionMethod)
     bundle = BM.get_model(method)
     model = BM.get_model(bundle)
     @variable(model, -1 <= x[i=1:bundle.n] <= 1)

--- a/src/TrustRegion.jl
+++ b/src/TrustRegion.jl
@@ -26,11 +26,12 @@ mutable struct TrustRegionMethod <: AbstractMethod
     ξ::Float64              # serious step criterion
     ϵ::Float64              # convergence criterion
 
+    x_lb::Array{Float64,1}  # original variable lower bound
+    x_ub::Array{Float64,1}  # original variable upper bound
     Δ::Float64              # current trust region size
     x0::Array{Float64,1}	# current trust region center (at iteration k)
     fx0::Array{Float64,1}	# current best objective values
 
-    tr_pool::Vector{JuMP.ConstraintRef} # references to current trust region bounds
     statistics::Dict{Any,Any} # arbitrary collection of statistics
 
     null_count::Int         # ineffective search count
@@ -55,11 +56,12 @@ mutable struct TrustRegionMethod <: AbstractMethod
         trm.ξ = 1.0e-4
         trm.ϵ = 1.0e-6
 
+        trm.x_lb = zeros(n)
+        trm.x_ub = zeros(n)
         trm.Δ = 100.0
         trm.x0 = copy(init)
         trm.fx0 = copy(trm.fy)
 
-        trm.tr_pool = []
         trm.statistics = Dict()
 
         trm.null_count = 0
@@ -68,6 +70,23 @@ mutable struct TrustRegionMethod <: AbstractMethod
         trm.model = BundleModel(n, N, func)
         return trm
     end
+end
+
+function store_initial_variable_bounds!(method::TrustRegionMethod)
+    bundle = get_model(method)
+    model = get_model(bundle)
+    x = model[:x]
+    for i = 1:bundle.n
+        method.x_lb[i] = ifelse(has_lower_bound(x[i]), lower_bound(x[i]), -Inf)
+        method.x_ub[i] = ifelse(has_upper_bound(x[i]), upper_bound(x[i]), +Inf)
+    end
+end
+
+function build_bundle_model!(method::TrustRegionMethod)
+    add_variables!(method)
+    store_initial_variable_bounds!(method)
+    add_objective_function!(method)
+    add_constraints!(method)
 end
 
 # This returns BundleModel object.
@@ -95,12 +114,9 @@ function add_constraints!(method::TrustRegionMethod)
     Δ = method.Δ
     x = model[:x]
     center = method.x0
-    method.tr_pool = []
     for i = 1:bundle.n
-        ref = @constraint(model, x[i] <= center[i] + Δ)
-        push!(method.tr_pool, ref)
-        ref = @constraint(model, x[i] >= center[i] - Δ)
-        push!(method.tr_pool, ref)
+        set_lower_bound(x[i], max(center[i] - Δ, method.x_lb[i]))
+        set_upper_bound(x[i], min(center[i] + Δ, method.x_ub[i]))
     end
 end
 
@@ -192,11 +208,6 @@ function update_bundles!(method::TrustRegionMethod)
             update_Δ_null_step!(method, ρ)
             method.null_count = 0
         end
-    end
-    # remove old trust region bounds
-    model = get_jump_model(method)
-    for (i, ref) in enumerate(method.tr_pool)
-        delete(model, ref)
     end
     # add new trust region bounds
     add_constraints!(method::TrustRegionMethod)    


### PR DESCRIPTION
- Changed the code for the trust region to use variable bounds (vs. generic linear constraints). This will display the correct number of rows. 
- Fixed the trust region example to be standalone